### PR TITLE
Fix the order of actions for rule updates of existing collections

### DIFF
--- a/src/collectionCronJob.ts
+++ b/src/collectionCronJob.ts
@@ -119,9 +119,9 @@ export const collectionCronJob = async () => {
       // Rule hasn't changed, do nothing
       if (collectionRule.value === ruleValue) continue;
 
-      // If the rules have changed, create new rules and the delete old one
-      await createTwitterStreamRules(entry, collectionId);
+      // If the rules have changed, the delete old one and create the new rule
       await twitter.deleteRulesFromStream([collectionRule.id]);
+      await createTwitterStreamRules(entry, collectionId);
 
       // Trigger a backfill
       await backfillCollection(entry, collectionId);

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -138,7 +138,7 @@ export class TwitterAPI {
   // Get all applied rules to the FilteredStream
   async getAllStreamRules() {
     const responseObject = await this.appOnlyClient.v2.streamRules();
-    return responseObject.data;
+    return responseObject.data || [];
   }
 
   // Add a set of rules to a Twitter FilteredStream


### PR DESCRIPTION
This fixes a bug with the Twitter collection management code that I noticed last week when we launched Galo's pub. 

The correct order of operations is to delete the existing rule first and then create the new rule.
